### PR TITLE
Remove grey background from docutils' output

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,6 +35,14 @@ async function rstToHtml() {
     `);
 
     outputFrame.srcdoc = result;
+
+    // Override Docutils' default style, which adds a grey background to the body element.
+    // We need to wait until the iframe's load event; see https://stackoverflow.com/a/13959836/266309.
+    outputFrame.addEventListener("load", event => {
+      const newStyle = outputFrame.contentDocument.createElement("style");
+      newStyle.textContent = "body { background-color: unset; }";
+      event.target.contentDocument.head.appendChild(newStyle);
+    });
   } catch (err) {
     const pre = document.createElement('pre');
     pre.textContent = err;


### PR DESCRIPTION
This has to be done via string manipulation instead of DOM manipulation, because the iframe's contents are set by passing a string with HTML markup to the `srcdoc` attribute (see PR #12).

Fixes #15.
