### PR TITLE
Updgrade Pyodide to 23.1

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Live rST playground</title>
     <meta name="viewport" content="width=device-width" />
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.22.0/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.23.1/pyc/pyodide.js"></script>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>

--- a/script.js
+++ b/script.js
@@ -19,8 +19,10 @@ function checkForWebAssembly() {
 
 // Initialize Pyodide
 async function main() {
+  const startTime = Date.now();
   let pyodide = await loadPyodide();
-  outputFrame.contentDocument.write("Ready.\n");
+  const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
+  outputFrame.contentDocument.write(`Ready in ${elapsedTime}s.\n`);
   // This makes the browser favicon stop the loading spinner
   outputFrame.contentDocument.close();
 


### PR DESCRIPTION
- Add timing to show how long Pyodide took to load
- Updgrade Pyodide to 23.1 and use the py-compiled version.

Using the py-compiled version leads to faster load time.
See the blog post for more details: <https://blog.pyodide.org/posts/0.23-release/#load-time-and-size-optimizations>

Using the new timing function, my experiments showed a noticeable reduction in first-time load from ~6.5s to ~4.5s. Not world-shattering, but definitely significant. Note that this only happened when using the py-compiled version; the regular one still resulted in around the same loading time as 22.0.