### PR TITLE
Upgrade Pyodide to v0.24

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Live rST playground</title>
     <meta name="viewport" content="width=device-width" />
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.23.1/pyc/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.0/pyc/pyodide.js"></script>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>

--- a/script.js
+++ b/script.js
@@ -18,7 +18,10 @@ function checkForWebAssembly() {
 // Initialize Pyodide
 async function main() {
   const startTime = Date.now();
-  let pyodide = await loadPyodide();
+  // Load Pyodide along with the required packages to run docutils.
+  // The `pygments` package is included to support code blocks with language specifiers
+  // (they automatically trigger syntax highlighting)
+  let pyodide = await loadPyodide({ packages: [ "docutils", "pygments" ] });
   const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
   outputFrame.contentDocument.write(`Ready in ${elapsedTime}s.\n`);
   // This makes the browser favicon stop the loading spinner
@@ -49,10 +52,6 @@ async function rstToHtml() {
   try {
     checkForWebAssembly();
     let pyodide = await pyodideReadyPromise;
-    await pyodide.loadPackage("docutils");
-    // Add pygments to support code blocks with language specifiers
-    // (they automatically trigger syntax highlighting)
-    await pyodide.loadPackage("pygments");
 
     // We pass the textarea contents as a variable
     // instead of interpolating them into the code below.


### PR DESCRIPTION
In this release, `loadPyodide()` gained a `packages` argument, so packages can now be downloaded during the Pyodide bootstrap.

References:
- [Announcement blog post for Pyodide 0.24](https://blog.pyodide.org/posts/0.24-release/)
- [Reference docs for `loadPyodide`](https://pyodide.org/en/0.24.0/usage/api/js-api.html#globalThis.loadPyodide)