### PR TITLE
Get only rendered content body from Docutils

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -22,7 +22,7 @@
       <label for="rst-input">reStructuredText input</label>
       <label for="html-output">HTML output</label>
       <textarea name="rst_input" id="rst-input" autofocus="true" disabled="true"></textarea>
-      <iframe id="html-output"></iframe>
+      <output name="html_output" id="html-output" for="rst-input"></output>
     </form>
 
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ form {
   column-gap: 1em;
 }
 textarea,
-iframe {
+output {
   border: 1px solid grey;
   border-radius: 3px;
   padding: 0.5em;
@@ -18,4 +18,5 @@ iframe {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
+  overflow-y: auto;
 }


### PR DESCRIPTION
Instead of getting a full HTML document, we now get only the contents of the body (see <https://docutils.sourceforge.io/docs/api/publisher.html#html-body>), which means it no longer needs to be put in an `<iframe>`.

Fixes #5

Note: by not getting the full HTML document, with stylesheets and everything, we will now need to style the output ourselves, so #21 is even more important now. In particular, compare the before/after of this PR:

| Before | After |
| ------ | ----- |
| <img width="1599" height="1234" alt="image" src="https://github.com/user-attachments/assets/44ee0a4f-5619-4ddb-aa8a-7c99b3a129ad" /> | <img width="1599" height="1234" alt="image" src="https://github.com/user-attachments/assets/1d67b099-8da3-4213-aeb0-05f8df4f3d1c" /> |