### PR TITLE
Improve styling based on Downstyler

### DIFF
--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,2 +1,2 @@
 trailingComma = "es5"
-printWidth = 100
+printWidth = 120

--- a/index.xhtml
+++ b/index.xhtml
@@ -5,6 +5,7 @@
     <title>Live rST playground</title>
     <meta name="viewport" content="width=device-width" />
     <script src="https://cdn.jsdelivr.net/pyodide/v0.28.0/pyc/pyodide.js"></script>
+    <link rel="stylesheet" href="https://raw.githack.com/waldyrious/downstyler/master/downstyler.css" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>

--- a/script.js
+++ b/script.js
@@ -9,9 +9,7 @@ outputField.value = "Initializing...";
 // Check if the browser supports WebAssembly
 function checkForWebAssembly() {
   if (!("WebAssembly" in window)) {
-    throw new Error(
-      "This website requires WebAssembly because it depends on Pyodide to run docutils in the browser"
-    );
+    throw new Error("This website requires WebAssembly because it depends on Pyodide to run docutils in the browser");
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 body {
-  margin: 1em;
+  max-width: unset; /* override max-width from downstyler */
 }
 form {
   margin-bottom: 1em;
@@ -8,10 +8,14 @@ form {
   grid-template-rows: auto calc(100vh - 9em);
   column-gap: 1em;
 }
+textarea {
+  font-family: monospace; /* override font-family from downstyler */
+  font-size-adjust: 0.44;
+}
 textarea,
 output {
   border: 1px solid grey;
-  border-radius: 3px;
+  border-radius: 0 3px 3px 3px;
   padding: 0.5em;
   margin: 0;
   display: block;
@@ -19,4 +23,13 @@ output {
   width: 100%;
   height: 100%;
   overflow-y: auto;
+}
+label {
+  background: LightSkyBlue;
+  width: max-content;
+  padding: 0 0.5em;
+  border-radius: 5px 5px 0 0;
+  font-weight: bold;
+  border: 1px solid gray;
+  border-bottom: none;
 }

--- a/style.css
+++ b/style.css
@@ -33,3 +33,58 @@ label {
   border: 1px solid gray;
   border-bottom: none;
 }
+/* Styles for the docutils output */
+output {
+  pre {
+    margin: 0.7em;
+    padding: 0.5em;
+    color: initial;
+  }
+  aside {
+    padding: 0.5em 1em;
+    &.admonition {
+      border-left: thick solid #0074d9;
+      background: #f0f8ff;
+    }
+    &.system-message {
+      border-left: thick solid crimson;
+      background: #fff0f0;
+    }
+    &.footnote-list {
+      border-left: thin solid darkgray;
+      padding: 0 0.3em;
+      margin-block: 0.4em;
+      aside {
+        padding: 0;
+      }
+    }
+    p[class$="-title"] {
+      font-weight: bold;
+      font-size: 1.1em;
+    }
+  }
+  :is(table, aside) :is(p, dl, .line-block) {
+    margin-block: 0.5em;
+  }
+  .docinfo {
+    dt {
+      float: left;
+      clear: left;
+      width: 120px;
+      font-weight: bold;
+    }
+    dd {
+      float: left;
+      margin-left: 0;
+      padding-left: 0.5em;
+      p {
+        margin: 0;
+      }
+    }
+    &::after {
+      content: "";
+      display: block;
+      clear: left;
+    }
+  }
+}


### PR DESCRIPTION
Add proper styling to display the HTML produced by docutils in a readable way. Relies heavily in [Downstyler](https://github.com/waldyrious/downstyler) for the core styling, plus some 

#### Screenshots

<details>
<summary>Before</summary>

<img width="1599" height="1234" alt="image" src="https://github.com/user-attachments/assets/b8143757-9163-43dd-9b90-9ada40098bf9" />

</details>

<details>
<summary>After</summary>

<img width="1599" height="1234" alt="image" src="https://github.com/user-attachments/assets/d814063d-f904-48ae-b648-13cf627201bf" />

</details>

<details>
<summary>Docutils' default style</summary>

<img width="1599" height="1234" alt="image" src="https://github.com/user-attachments/assets/44ee0a4f-5619-4ddb-aa8a-7c99b3a129ad" />

</details>

Note: the "After" screenshot has been zoomed out to 80% to provide a more equitable comparison, since Downstyler scales the font size proportionally to the viewport width.

Fixes #21