### PR TITLE
Restore iframe approach

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -22,16 +22,14 @@
         by running <a href="https://docutils.sourceforge.io">docutils</a> (a Python program)
         in the browser using <a href="https://pyodide.org">Pyodide</a>.
       </p>
+      <noscript><mark><strong>Note:</strong> This page requires JavaScript to work.</mark></noscript>
     </header>
 
     <form>
       <label for="rst-input">reStructuredText input</label>
       <label for="html-output">HTML output</label>
       <textarea name="rst_input" id="rst-input" autofocus="true" disabled="true"></textarea>
-      <output name="html_output" id="html-output" for="rst-input">
-        <!-- prettier-ignore -->
-        <noscript><mark><strong>Note:</strong> This page requires JavaScript to work.</mark></noscript>
-      </output>
+      <iframe id="html-output"></iframe>
     </form>
 
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -1,17 +1,13 @@
 body {
   max-width: unset; /* override max-width from downstyler */
 }
-header {
-  margin-bottom: 1em;
-  h1 {
-    margin: 0;
-  }
-  p {
-    margin-block: 0.5em;
-  }
+header > * {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
 }
 form {
-  margin-bottom: 1em;
+  margin-block: 1em;
   display: grid;
   grid-template-columns: repeat(2, calc((100% - 1em) / 2));
   grid-template-rows: auto calc(100vh - 12em);

--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@ textarea {
   font-size-adjust: 0.44;
 }
 textarea,
-output {
+iframe {
   border: 1px solid grey;
   border-radius: 0 3px 3px 3px;
   padding: 0.5em;
@@ -41,59 +41,4 @@ label {
   font-weight: bold;
   border: 1px solid gray;
   border-bottom: none;
-}
-/* Styles for the docutils output */
-output {
-  pre {
-    margin: 0.7em;
-    padding: 0.5em;
-    color: initial;
-  }
-  aside {
-    padding: 0.5em 1em;
-    &.admonition {
-      border-left: thick solid #0074d9;
-      background: #f0f8ff;
-    }
-    &.system-message {
-      border-left: thick solid crimson;
-      background: #fff0f0;
-    }
-    &.footnote-list {
-      border-left: thin solid darkgray;
-      padding: 0 0.3em;
-      margin-block: 0.4em;
-      aside {
-        padding: 0;
-      }
-    }
-    p[class$="-title"] {
-      font-weight: bold;
-      font-size: 1.1em;
-    }
-  }
-  :is(table, aside) :is(p, dl, .line-block) {
-    margin-block: 0.5em;
-  }
-  .docinfo {
-    dt {
-      float: left;
-      clear: left;
-      width: 120px;
-      font-weight: bold;
-    }
-    dd {
-      float: left;
-      margin-left: 0;
-      padding-left: 0.5em;
-      p {
-        margin: 0;
-      }
-    }
-    &::after {
-      content: "";
-      display: block;
-      clear: left;
-    }
-  }
 }


### PR DESCRIPTION
After having experimented with getting only the HTML content of `docutils`'s output and putting it into an `<output>` form element, it became clear that the previous approach of using an iframe is more appropriate, since it provides a natural container to encapsulate `docutils`'s HTML and CSS, which, it turns out, are both needed for properly viewing the rendered rich text. Specifically, `docutils`'s CSS contains styles that address many bespoke structures that don't rely solely on semantic HTML elements, but rather on CSS classes.

In essence, this PR reverts #36, with some tweaks to cater to other changes done since then (which accounts for this PR's diff not being an exact reversal of #36's diff).

Fixes #41.