### PR TITLE
Prettier check: use opt-out instead of opt-in

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -19,4 +19,4 @@ jobs:
           node-version: "22" # Current LTS version
 
       - name: Check code formatting with Prettier
-        run: npx prettier@3.6.2 --check './*.{js,css,html,md}'
+        run: npx prettier@3.6.2 --check . '!css/downstyler'


### PR DESCRIPTION
Explicitly exclude the downstyler submodule, but process everything else.