### PR TITLE
Revert "Serve Pyodide dependency from CDNjs instead of jsDelivr"

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Live rST playground</title>
     <meta name="viewport" content="width=device-width" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pyodide/0.25.0/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.25.0/pyc/pyodide.js"></script>
     <link rel="stylesheet" href="css/downstyler/downstyler.css" />
     <link rel="stylesheet" href="css/style.css" />
   </head>


### PR DESCRIPTION
This reverts commit b6d4b99eba947866b65e97fa62f9b2094973dbfc from PR #60.

The Pyodide dependency fails to load properly when fetched from CDNjs.
Reverting to jsDelivr to get the playground working again.
